### PR TITLE
fix(deps): unblock standalone pub resolution in super_editor

### DIFF
--- a/super_editor/example/pubspec.yaml
+++ b/super_editor/example/pubspec.yaml
@@ -44,8 +44,6 @@ dependencies:
   # super_editor_markdown removed — markdown serialization consolidated into super_editor core (v0.3.0-dev.40)
   super_editor:
     path: ../
-  super_text_layout:
-    path: ../../super_text_layout
   super_keyboard: ^0.3.0
   follow_the_leader: ^0.5.1
   overlord: ^0.4.2

--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
 dev_dependencies:
   args: ^2.3.1
   flutter_lints: ^6.0.0
-  flutter_test_runners: ^1.0.0
+  flutter_test_runners: ^0.0.4
   flutter_test_goldens: ^0.0.7
   golden_bricks: ^1.0.0
   golden_runner: ^0.2.0


### PR DESCRIPTION
## Summary
- downgrade `flutter_test_runners` in `super_editor` to `^0.0.4` to match `super_keyboard`
- remove conflicting direct `super_text_layout` path dependency from `super_editor/example`
- restore successful standalone `flutter pub get` for both package and example

## Test plan
- [x] `flutter pub get` in `super_editor/super_editor`