### PR TITLE
fix(deps): align super_editor test runner constraints

### DIFF
--- a/super_editor/pubspec.yaml
+++ b/super_editor/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   logging: ^1.3.0
   markdown: ^7.2.1
   super_text_layout: ^0.1.18
-  super_keyboard: ^0.3.0
+  super_keyboard: ^0.3.1
   url_launcher: ^6.3.1
   uuid: ^4.5.1
   overlord: ^0.4.2

--- a/super_editor_clipboard/pubspec.yaml
+++ b/super_editor_clipboard/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   collection: ^1.19.1
   flutter:
     sdk: flutter
-  flutter_test_runners: ^1.0.0
+  flutter_test_runners: ^0.0.4
   html2md: ^1.3.2
   logging: ^1.3.0
   super_clipboard: ^0.9.1

--- a/super_editor_markdown/pubspec.yaml
+++ b/super_editor_markdown/pubspec.yaml
@@ -41,7 +41,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_test_robots: ^1.0.0
-  flutter_test_runners: ^1.0.0
+  flutter_test_runners: ^0.0.4
   golden_toolkit: ^0.15.0
 
   super_text_layout: ^0.1.12

--- a/super_editor_spellcheck/pubspec.yaml
+++ b/super_editor_spellcheck/pubspec.yaml
@@ -31,7 +31,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   pigeon: ^26.1.2
   flutter_test_goldens: ^0.0.7
-  flutter_test_runners: ^1.0.0
+  flutter_test_runners: ^0.0.4
   flutter_test_robots: ^1.0.0
   golden_bricks: ^1.0.0
 

--- a/super_keyboard/pubspec.yaml
+++ b/super_keyboard/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   # So that we can expose test tools to apps.
   flutter_test:
     sdk: flutter
-  flutter_test_runners: ^1.0.0
+  flutter_test_runners: ^0.0.4
 
 dev_dependencies:
   flutter_lints: ^6.0.0


### PR DESCRIPTION
## Summary
- bump `super_editor` to `super_keyboard ^0.3.1`
- align `flutter_test_runners` to `^0.0.4` across `super_keyboard`, `super_editor_clipboard`, `super_editor_markdown`, and `super_editor_spellcheck`
- resolve version solver conflicts that block workspace resolution

## Test plan
- [x] `mani run set-pub-resolution && flutter pub get && mani run unset-pub-resolution` from `unified_monorepo`